### PR TITLE
ExpandableListViewAssertion and CalculonStoryTest fix

### DIFF
--- a/src/main/java/com/github/calculon/CalculonStoryTest.java
+++ b/src/main/java/com/github/calculon/CalculonStoryTest.java
@@ -6,9 +6,10 @@ import android.test.ActivityInstrumentationTestCase2;
 
 import com.github.calculon.assertion.CalculonAssertions;
 import com.github.calculon.story.StoryTestActivityStack;
+import com.github.calculon.support.ActivityLauncher;
 
 public abstract class CalculonStoryTest<ActivityT extends Activity> extends
-        ActivityInstrumentationTestCase2<ActivityT> {
+        ActivityInstrumentationTestCase2<ActivityT> implements CalculonTestCase{
 
     private Class<ActivityT> mActivityClass = null;
     private StoryTestActivityStack activityStack = null;
@@ -17,6 +18,13 @@ public abstract class CalculonStoryTest<ActivityT extends Activity> extends
         super(pkg, activityClass);
         mActivityClass = activityClass;
     }
+
+    @Override
+    public ActivityLauncher.LaunchConfiguration getLaunchConfiguration() {
+        return new ActivityLauncher.LaunchConfiguration();
+    }
+
+
 
     @Override
     protected void setUp() throws Exception {
@@ -45,6 +53,11 @@ public abstract class CalculonStoryTest<ActivityT extends Activity> extends
 
     public Activity getCurrentActivity() {
         return activityStack.pop();
+    }
+
+    @Override
+    public Class<? extends Activity> getActivityClass() {
+        return mActivityClass;
     }
 
     // protected void flipScreen(Activity activity) {

--- a/src/main/java/com/github/calculon/assertion/CalculonAssertions.java
+++ b/src/main/java/com/github/calculon/assertion/CalculonAssertions.java
@@ -3,15 +3,12 @@ package com.github.calculon.assertion;
 import static junit.framework.Assert.assertNotNull;
 import android.app.Activity;
 import android.content.Intent;
+import android.test.ActivityInstrumentationTestCase2;
+import android.test.ActivityTestCase;
 import android.test.InstrumentationTestCase;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
-import android.widget.ListView;
-import android.widget.RadioButton;
-import android.widget.TextView;
-import android.widget.ToggleButton;
+import android.widget.*;
 
 import com.github.calculon.CalculonTestCase;
 
@@ -127,6 +124,10 @@ public class CalculonAssertions {
 
     public static ListViewAssertion assertThat(ListView view) {
         return new ListViewAssertion(testCase, getActivity(), view);
+    }
+
+    public static ExpandableListViewAssertion assertThat(ExpandableListView view) {
+        return new ExpandableListViewAssertion(testCase, getActivity(), view);
     }
 
     public static TextViewAssertion assertThat(TextView view) {

--- a/src/main/java/com/github/calculon/assertion/ExpandableListViewAssertion.java
+++ b/src/main/java/com/github/calculon/assertion/ExpandableListViewAssertion.java
@@ -1,0 +1,134 @@
+package com.github.calculon.assertion;
+
+import android.app.Activity;
+import android.test.InstrumentationTestCase;
+import android.view.View;
+import android.widget.ExpandableListAdapter;
+import android.widget.ExpandableListView;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.*;
+
+public class ExpandableListViewAssertion extends ViewAssertion {
+
+    private ExpandableListView listView;
+
+    public ExpandableListViewAssertion(InstrumentationTestCase testCase, Activity activity, ExpandableListView listView) {
+        super(testCase, activity, listView);
+        this.listView = listView;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ActionAssertion<ExpandableListViewAssertion> click() {
+        return (ActionAssertion<ExpandableListViewAssertion>) super.click();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ActionAssertion<ExpandableListViewAssertion> longClick() {
+        return (ActionAssertion<ExpandableListViewAssertion>) super.longClick();
+    }
+
+    public void hasGroups() {
+        assertFalse("list view expected not to be empty, but it was", getAdapter().getGroupCount() > 0);
+    }
+
+    public void hasGroups(int count) {
+        int actual = getAdapter().getGroupCount();
+        assertEquals("list group count mismatch:", count, actual);
+    }
+
+    public void isEmpty() {
+        assertTrue("list view expected to be empty, but wasn't", getAdapter().isEmpty());
+    }
+
+    public ViewAssertion group(int position) {
+        return new ViewAssertion(testCase, activity, getGroupView(position));
+    }
+
+    public ViewAssertion child(int groupPosition, int childPosition) {
+        boolean lastChild = isLastChild(groupPosition, childPosition);
+        return new ViewAssertion(testCase, activity, getChildView(groupPosition, childPosition, lastChild));
+    }
+
+    private boolean isLastChild(int groupPosition, int childPosition) {
+        return (childPosition == getAdapter().getChildrenCount(groupPosition) - 1);
+    }
+
+    public ViewAssertion firstGroup() {
+        return group(0);
+    }
+
+    public ViewAssertion lastGroup() {
+        return group(getAdapter().getGroupCount() - 1);
+    }
+
+    public ViewAssertion firstChild(int groupPosition) {
+        return child(groupPosition, 0);
+    }
+
+    public ViewAssertion lastChild(int groupPosition) {
+        return child(getAdapter().getGroupCount() - 1, getAdapter().getChildrenCount(groupPosition) - 1);
+    }
+
+    public MultiViewAssertion groups() {
+        ExpandableListAdapter adapter = getAdapter();
+        int count = adapter.getGroupCount();
+        List<View> views = new ArrayList<View>(count);
+        for (int i = 0; i < count; i++) {
+            views.add(adapter.getGroupView(i, false, null, listView));
+        }
+        return new MultiViewAssertion(testCase, activity, views);
+    }
+
+    public MultiViewAssertion children(int groupPosition) {
+        ExpandableListAdapter adapter = getAdapter();
+        int count = adapter.getChildrenCount(groupPosition);
+        List<View> views = new ArrayList<View>(count);
+        boolean lastChild;
+        for (int i = 0; i < count; i++) {
+            lastChild = isLastChild(groupPosition, i);
+            views.add(adapter.getChildView(groupPosition, i, lastChild, null, listView));
+        }
+        return new MultiViewAssertion(testCase, activity, views);
+    }
+
+    public ActionAssertion<?> clickChild(final int groupPosition, final int childPosition) {
+        return AssertionResolver.actionAssertion(this, testCase, activity, new Runnable() {
+            public void run() {
+                View itemView = getChildView(groupPosition, childPosition, false);
+                assertNotNull("item view at position " + groupPosition + " was null", itemView);
+                itemView.performClick();
+            }
+        }, true);
+    }
+    public ActionAssertion<?> clickGroup(final int groupPosition) {
+        return AssertionResolver.actionAssertion(this, testCase, activity, new Runnable() {
+            public void run() {
+                View itemView = getGroupView(groupPosition);
+                assertNotNull("item view at position " + groupPosition + " was null", itemView);
+                itemView.performClick();
+                //listView.performItemClick(itemView, groupPosition, itemView.getId());
+            }
+        }, true);
+    }
+
+    private View getGroupView(int groupPosition) {
+        return getAdapter().getGroupView(groupPosition, false, null, listView);
+    }
+
+    private View getChildView(int groupPosition, int childPosition, boolean lastChild) {
+        return getAdapter().getChildView(groupPosition, childPosition, lastChild, null, listView);
+    }
+
+    private ExpandableListAdapter getAdapter() {
+        ExpandableListAdapter adapter = listView.getExpandableListAdapter();
+        assertNotNull("list adapter expected to exist, but was null", adapter);
+        return adapter;
+    }
+}


### PR DESCRIPTION
Hi Matthias, I've been playing around with Calculon for a bit and found it really useful, I love the fluent style it makes possible. 

I've made one addition which you might like to pull, it adds an ExpandableListViewAssertion type to enable assertions against ExpandableListViews.

I also had to make CalculonStoryTest implement CalculonTestCase because otherwise you get a class cast exception in CalculonAssertions.getActivity() when using the CalculonStoryTest type. 

I think I might be missing some of the subtleties of that interface so you will want to check my implementation particularly of getLaunchConfiguration() as I couldn't really see what behaviour was expected from this. 

If I've misunderstood something and this implementation is not actually needed, it would be great if you could show me what I've missed.

Cheers,
Rupert
