### PR TITLE
Some more fixes and new stuff

### DIFF
--- a/src/main/java/com/github/calculon/CalculonSingleLaunchStoryTest.java
+++ b/src/main/java/com/github/calculon/CalculonSingleLaunchStoryTest.java
@@ -1,0 +1,72 @@
+package com.github.calculon;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import android.test.SingleLaunchActivityTestCase;
+import com.github.calculon.assertion.CalculonAssertions;
+import com.github.calculon.story.StoryTestActivityStack;
+import com.github.calculon.support.ActivityLauncher;
+
+public abstract class CalculonSingleLaunchStoryTest<ActivityT extends Activity>
+        extends SingleLaunchActivityTestCase<ActivityT>
+        implements CalculonTestCase, CalculonStory{
+
+    private Class<ActivityT> mActivityClass;
+    private StoryTestActivityStack activityStack = null;
+
+    public CalculonSingleLaunchStoryTest(String pkg, Class<ActivityT> activityClass){
+        super(pkg, activityClass);
+        mActivityClass = activityClass;
+    }
+
+    @Override
+    public ActivityLauncher.LaunchConfiguration getLaunchConfiguration() {
+        return new ActivityLauncher.LaunchConfiguration();
+    }
+
+
+
+    @Override
+    protected void setUp() throws Exception {
+        //setActivityInitialTouchMode(false);
+
+        CalculonAssertions.register(this);
+        super.setUp();
+        activityStack = new StoryTestActivityStack(getActivity());
+//        Intent startingIntent = new Intent(getInstrumentation().getTargetContext(), mActivityClass
+//                .getClass());
+//
+//        setUp(startingIntent);
+    }
+
+    protected void setUp(Intent startingIntent) throws Exception {
+        startingIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startingIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+        //setActivityIntent(startingIntent);
+
+        //super.setUp();
+
+        activityStack = new StoryTestActivityStack(getActivity());
+        //setActivityInitialTouchMode(false);
+
+        CalculonAssertions.register(this);
+    }
+
+    @Override
+    public void setCurrentActivity(Activity currentActivity) {
+        activityStack.push(currentActivity);
+    }
+
+    public Activity getCurrentActivity() {
+
+        return activityStack.pop();
+    }
+
+    @Override
+    public Class<? extends Activity> getActivityClass() {
+        return mActivityClass;
+    }
+
+}

--- a/src/main/java/com/github/calculon/CalculonStory.java
+++ b/src/main/java/com/github/calculon/CalculonStory.java
@@ -1,0 +1,9 @@
+package com.github.calculon;
+
+import android.app.Activity;
+
+public interface CalculonStory<ActivityT extends Activity> {
+    public void setCurrentActivity(Activity currentActivity) ;
+
+    public Activity getCurrentActivity();
+}

--- a/src/main/java/com/github/calculon/CalculonStoryTest.java
+++ b/src/main/java/com/github/calculon/CalculonStoryTest.java
@@ -9,7 +9,7 @@ import com.github.calculon.story.StoryTestActivityStack;
 import com.github.calculon.support.ActivityLauncher;
 
 public abstract class CalculonStoryTest<ActivityT extends Activity> extends
-        ActivityInstrumentationTestCase2<ActivityT> implements CalculonTestCase{
+        ActivityInstrumentationTestCase2<ActivityT> implements CalculonTestCase, CalculonStory{
 
     private Class<ActivityT> mActivityClass = null;
     private StoryTestActivityStack activityStack = null;

--- a/src/main/java/com/github/calculon/CalculonStoryTest.java
+++ b/src/main/java/com/github/calculon/CalculonStoryTest.java
@@ -30,16 +30,17 @@ public abstract class CalculonStoryTest<ActivityT extends Activity> extends
     protected void setUp() throws Exception {
         Intent startingIntent = new Intent(getInstrumentation().getTargetContext(), mActivityClass
                 .getClass());
-        startingIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        startingIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         setUp(startingIntent);
     }
 
     protected void setUp(Intent startingIntent) throws Exception {
+        startingIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startingIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
         setActivityIntent(startingIntent);
 
-        super.setUp();
+        //super.setUp();
 
         activityStack = new StoryTestActivityStack(getActivity());
         setActivityInitialTouchMode(false);

--- a/src/main/java/com/github/calculon/assertion/AssertionBase.java
+++ b/src/main/java/com/github/calculon/assertion/AssertionBase.java
@@ -3,8 +3,7 @@ package com.github.calculon.assertion;
 import android.app.Activity;
 import android.app.Instrumentation;
 import android.test.InstrumentationTestCase;
-
-import com.github.calculon.CalculonStoryTest;
+import com.github.calculon.CalculonStory;
 import com.github.calculon.CalculonUnitTest;
 
 public abstract class AssertionBase {
@@ -25,7 +24,7 @@ public abstract class AssertionBase {
     }
 
     @SuppressWarnings("unchecked")
-    public CalculonStoryTest<Activity> getStoryTestCase() {
-        return (CalculonStoryTest<Activity>) testCase;
+    public CalculonStory<Activity> getStoryTestCase() {
+        return (CalculonStory<Activity>) testCase;
     }
 }

--- a/src/main/java/com/github/calculon/assertion/AssertionResolver.java
+++ b/src/main/java/com/github/calculon/assertion/AssertionResolver.java
@@ -3,6 +3,8 @@ package com.github.calculon.assertion;
 import android.app.Activity;
 import android.test.InstrumentationTestCase;
 
+import com.github.calculon.CalculonSingleLaunchStoryTest;
+import com.github.calculon.CalculonStory;
 import com.github.calculon.CalculonStoryTest;
 import com.github.calculon.CalculonUnitTest;
 import com.github.calculon.assertion.story.StoryTestActionAssertion;
@@ -16,12 +18,12 @@ public class AssertionResolver {
         if (testCase instanceof CalculonUnitTest<?>) {
             return new UnitTestActionAssertion<AssertionT>(fromAssertion, testCase, activity,
                     action, runOnMainThread);
-        } else if (testCase instanceof CalculonStoryTest<?>) {
+        } else if (testCase instanceof CalculonStory) {
             return new StoryTestActionAssertion<AssertionT>(fromAssertion, testCase, activity,
                     action, runOnMainThread);
         } else {
             throw new IllegalArgumentException("Test case must be either a "
-                    + CalculonUnitTest.class.getName() + " or " + CalculonStoryTest.class.getName());
+                    + CalculonUnitTest.class.getName() + " or " + CalculonStory.class.getName());
         }
     }
 }

--- a/src/main/java/com/github/calculon/assertion/ListViewAssertion.java
+++ b/src/main/java/com/github/calculon/assertion/ListViewAssertion.java
@@ -11,6 +11,7 @@ import java.util.List;
 import android.app.Activity;
 import android.test.InstrumentationTestCase;
 import android.view.View;
+import android.widget.HeaderViewListAdapter;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 
@@ -38,10 +39,41 @@ public class ListViewAssertion extends ViewAssertion {
     public void hasItems() {
         assertFalse("list view expected not to be empty, but it was", getAdapter().isEmpty());
     }
+    private int getCount(){
+        ListAdapter adapter = getAdapter();
+        if(adapter.getClass() != HeaderViewListAdapter.class)
+            return adapter.getCount();
 
+        HeaderViewListAdapter headerViewListAdapter = (HeaderViewListAdapter) adapter;
+        return headerViewListAdapter.getCount() - (headerViewListAdapter.getFootersCount() + headerViewListAdapter.getHeadersCount());
+    }
+    public void hasFooter(){
+        ListAdapter adapter = getAdapter();
+        assertTrue("list was expected to have a footer, but does not", adapter.getClass() == HeaderViewListAdapter.class &&
+                ((HeaderViewListAdapter)adapter).getFootersCount() > 0);
+
+
+    }
+    public void hasHeader(){
+        ListAdapter adapter = getAdapter();
+        assertTrue("list was expected to have a header, but does not", adapter.getClass() == HeaderViewListAdapter.class &&
+                ((HeaderViewListAdapter)adapter).getHeadersCount() > 0);
+
+
+    }
     public void hasItems(int count) {
-        int actual = getAdapter().getCount();
+        int actual = getCount();
         assertEquals("list item count mismatch:", count, actual);
+    }
+
+    public void hasMoreItemsThan(int count) {
+        int actual = getCount();
+        assertTrue("list item count was expected to be greater than " + count + " but it was " + actual, count < actual);
+    }
+
+    public void hasFewerItemsThan(int count) {
+        int actual = getCount();
+        assertTrue("list item count was expected to be less than " + count + " but it was " + actual , count > actual);
     }
 
     public void hasNoItems() {
@@ -57,12 +89,12 @@ public class ListViewAssertion extends ViewAssertion {
     }
 
     public ViewAssertion lastItem() {
-        return item(getAdapter().getCount() - 1);
+        return item(getCount() - 1);
     }
 
     public MultiViewAssertion items() {
         ListAdapter adapter = getAdapter();
-        int count = adapter.getCount();
+        int count = getCount();
         List<View> views = new ArrayList<View>(count);
         for (int i = 0; i < count; i++) {
             views.add(adapter.getView(i, null, listView));

--- a/src/main/java/com/github/calculon/assertion/ListViewAssertion.java
+++ b/src/main/java/com/github/calculon/assertion/ListViewAssertion.java
@@ -75,7 +75,8 @@ public class ListViewAssertion extends ViewAssertion {
             public void run() {
                 View itemView = getAdapter().getView(position, null, listView);
                 assertNotNull("item view at position " + position + " was null", itemView);
-                listView.performItemClick(itemView, position, itemView.getId());
+                itemView.performClick();
+                //listView.performItemClick(itemView, position, itemView.getId());
             }
         }, true);
     }


### PR DESCRIPTION
Hi Matthias, I've got a few more changes to calculon you may be interested in pulling:
-  Change the way that click() is implemented in ListViewAssertion - the previous implementation was failing for me in certain circumstances (unfortunately I can't remember exactly what they were) this implementation works consistently
-  Add some more List assertions    - I just added a few more generally useful assertions for lists, such as hasHeader(), and also fixed the hasItems(int count) assertion to work correctly when a list has a header or footer (previously these were included in the count)
-  Remove the call to super.setup in setup(Intent startingIntent) - this was causing any extras added to the startingIntent to be stripped off, the class still works fine without it.
-  Create a new test type CalculonSingleLaunchStoryTest for working with activities which have a launch mode other than normal - previously activities with a launch mode such as singleTop would often just stall while running and never complete, this fixes that

Let me know if you would rather I separated these commits out into different pull requests.

Cheers,
Rupert
